### PR TITLE
Use name prefix for ASG so it can be used with create before destroy …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_launch_configuration" "lc" {
 }
 
 resource "aws_autoscaling_group" "asg" {
-  name                      = var.cluster_name
+  name_prefix               = var.cluster_name
   vpc_zone_identifier       = var.subnet_ids
   min_size                  = var.min_size
   max_size                  = var.max_size


### PR DESCRIPTION
…lifecycle.